### PR TITLE
Show how to build example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Plain‑text animation language — Markdown for motion**
 
-Glimma lets you storyboard lightweight SVG/CSS animations in the same way Markdown lets you write documents. One `.glimma` file defines shapes, groups, scenes and timelines; the CLI turns it into a self‑contained HTML animation that plays in any modern browser.
+Glimma lets you storyboard lightweight SVG/CSS animations in the same way Markdown lets you write documents. One `.glimma` file defines shapes, groups, scenes and timelines; the CLI turns it into a self-contained SVG animation by default (add `--html` to wrap in an HTML page).
 
 > *If adding a feature makes the script harder to read than the concept it explains, drop it.* — Glimma founding rule
 
@@ -45,17 +45,28 @@ scene Intro {
 Build & preview:
 
 ```bash
-glimma build hello.glimma -o hello.html
-open hello.html   # on macOS; or just double‑click in Finder
+glimma build hello.glimma -o hello.svg
+open hello.svg   # on macOS; or just double-click in Finder
 ```
+
+Add `--html` if you want an HTML wrapper instead of raw SVG.
 
 ---
 
 ## CLI cheatsheet
 
+
+## Building from source
+
+```bash
+npm install
+npm run build
+node dist/cli/index.js examples/intro.glimma examples/intro.svg
+```
+
 | Command                 | Purpose                                          |
 | ----------------------- | ------------------------------------------------ |
-| `glimma build <file>`   | Compile to HTML bundle (default `out.html`).     |
+| `glimma build <file>`   | Compile to SVG (default `out.svg`, add `--html` for HTML). |
 | `glimma preview <file>` | Launch local web server with auto‑reload.        |
 | `glimma lint <file>`    | Validate syntax, report line/col errors.         |
 | `glimma init`           | Generate example scripts and CSS theme skeleton. |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,0 +1,4 @@
+# Glimma DSL Specification
+
+This document tracks the evolving MVP features for Glimma.
+Refer to the project README for the high level overview.

--- a/examples/intro.glimma
+++ b/examples/intro.glimma
@@ -1,0 +1,7 @@
+scene demo {
+  shape box rect x=10 y=10 width=100 height=50 fill="skyblue"
+  shape label text content="Hello" x=20 y=40
+  timeline:
+    0s: box fadeIn over 1s
+    0.5s: label fadeIn over 1s
+}

--- a/examples/intro.html
+++ b/examples/intro.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html><body>
+<svg xmlns="http://www.w3.org/2000/svg">
+<style>
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+#box { opacity: 0; animation: fadeIn 1s ease-in-out 0s forwards; }
+#label { opacity: 0; animation: fadeIn 1s ease-in-out 0.5s forwards; }
+</style>
+<g id="demo">
+<rect id="box" x="10" y="10" width="100" height="50" fill="skyblue" />
+<text id="label" content="Hello" x="20" y="40">Hello</text>
+</g>
+</svg>
+</body></html>

--- a/examples/intro.svg
+++ b/examples/intro.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<style>
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+#box { opacity: 0; animation: fadeIn 1s ease-in-out 0s forwards; }
+#label { opacity: 0; animation: fadeIn 1s ease-in-out 0.5s forwards; }
+</style>
+<g id="demo">
+<rect id="box" x="10" y="10" width="100" height="50" fill="skyblue" />
+<text id="label" content="Hello" x="20" y="40">Hello</text>
+</g>
+</svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,65 @@
+{
+  "name": "glimma",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "glimma",
+      "version": "1.0.0",
+      "license": "ISC",
+      "bin": {
+        "glimma": "dist/cli/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.1",
+        "pegjs": "^0.10.0",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
+      "integrity": "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/pegjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "integrity": "sha512-qI5+oFNEGi3L5HAxDwN2LA4Gg7irF70Zs25edhjld9QemOgp0CbvMtbFcMvFtEo1OityPrcCzkQFB8JP/hxgow==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pegjs": "bin/pegjs"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "glimma",
+  "version": "1.0.0",
+  "description": "**Plain‑text animation language — Markdown for motion**",
+  "main": "dist/cli/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "bin": {
+    "glimma": "dist/cli/index.js"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.1",
+    "pegjs": "^0.10.0",
+    "typescript": "^5.8.3"
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse } from '../parser/index.js';
+import { renderSvg, renderHtml } from '../renderer/index.js';
+
+const args = process.argv.slice(2);
+const htmlIdx = args.indexOf('--html');
+const useHtml = htmlIdx !== -1;
+if (htmlIdx !== -1) args.splice(htmlIdx, 1);
+
+const [input, outFile = useHtml ? 'out.html' : 'out.svg'] = args;
+
+if (!input) {
+  console.error('Usage: glimma <file.glimma> [out.svg|out.html] [--html]');
+  process.exit(1);
+}
+
+try {
+  const src = fs.readFileSync(path.resolve(input), 'utf8');
+  const ast = parse(src);
+  const output = useHtml ? renderHtml(ast) : renderSvg(ast);
+  fs.writeFileSync(path.resolve(outFile), output);
+  console.log(`Wrote ${outFile}`);
+} catch (err) {
+  console.error('Error:', err instanceof Error ? err.message : err);
+  process.exit(1);
+}

--- a/src/parser/grammar.pegjs
+++ b/src/parser/grammar.pegjs
@@ -1,0 +1,51 @@
+// Basic Glimma DSL grammar (MVP subset)
+
+Start
+  = _ scenes:Scene+ { return { type: 'Document', scenes } }
+
+Scene
+  = 'scene' _ name:Identifier _ '{' _ items:SceneItem* '}' _ {
+      return { type: 'Scene', name, items };
+    }
+
+SceneItem
+  = Shape
+  / Timeline
+
+Shape
+  = 'shape' _ id:Identifier _ type:Identifier _ attrs:AttributeList? _ {
+      return { type: 'Shape', id, shapeType: type, attrs: attrs || [] };
+    }
+
+Timeline
+  = 'timeline:' _ entries:TimelineEntry+ { return { type: 'Timeline', entries } }
+
+TimelineEntry
+  = time:Number 's:' _ target:Identifier _ action:Identifier _ attrs:AttributeList? _ 'over' _ dur:Number 's' _ {
+      return { type: 'TimelineEntry', time, target, action, attrs: attrs || [], dur };
+    }
+
+AttributeList
+  = _ attrs:Attribute+ { return attrs }
+
+Attribute
+  = name:Identifier '=' value:Value _ {
+      return { name, value };
+    }
+
+Value
+  = QuotedString / Number / Identifier
+
+Identifier
+  = [a-zA-Z_][a-zA-Z0-9_-]* { return text() }
+
+Number
+  = [0-9]+ ('.' [0-9]+)? { return parseFloat(text()) }
+
+QuotedString
+  = '"' chars:([^"\\] / '\\' .)* '"' {
+      return chars.join('');
+    }
+
+_ "whitespace"
+  = [ \t\n\r]*

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,0 +1,16 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import peg from 'pegjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Use grammar file from source directory even after compilation
+const grammarPath = path.resolve(__dirname, '../../src/parser/grammar.pegjs');
+const grammar = fs.readFileSync(grammarPath, 'utf8');
+const parser = peg.generate(grammar);
+
+export type ASTNode = any;
+
+export function parse(input: string): ASTNode {
+  return parser.parse(input);
+}

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,0 +1,52 @@
+import type { ASTNode } from '../parser/index.js';
+
+function renderCss(ast: ASTNode): string {
+  const rules: string[] = [];
+  let usesFade = false;
+  for (const scene of ast.scenes) {
+    const timeline = scene.items.find((i: any) => i.type === 'Timeline');
+    if (!timeline) continue;
+    for (const entry of timeline.entries) {
+      if (entry.action === 'fadeIn') {
+        usesFade = true;
+        rules.push(`#${entry.target} { opacity: 0; animation: fadeIn ${entry.dur}s ease-in-out ${entry.time}s forwards; }`);
+      }
+    }
+  }
+  if (usesFade) {
+    rules.unshift('@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }');
+  }
+  return rules.join('\n');
+}
+
+export function renderSvg(ast: ASTNode): string {
+  const scenes = ast.scenes.map((scene: any) => renderScene(scene)).join('\n');
+  const css = renderCss(ast);
+  return `<svg xmlns="http://www.w3.org/2000/svg">\n<style>\n${css}\n</style>\n${scenes}\n</svg>`;
+}
+
+export function renderHtml(ast: ASTNode): string {
+  return `<!DOCTYPE html>\n<html><body>\n${renderSvg(ast)}\n</body></html>`;
+}
+
+function renderScene(scene: any): string {
+  const items = scene.items
+    .filter((item: any) => item.type === 'Shape')
+    .map((item: any) => renderItem(item))
+    .join('\n');
+  return `<g id="${scene.name}">\n${items}\n</g>`;
+}
+
+function renderItem(item: any): string {
+  if (item.type === 'Shape') {
+    const attrs = item.attrs.map((a: any) => `${a.name}="${a.value}"`).join(' ');
+    if (item.shapeType === 'rect' || item.shapeType === 'circle' || item.shapeType === 'path') {
+      return `<${item.shapeType} id="${item.id}" ${attrs} />`;
+    }
+    if (item.shapeType === 'text') {
+      const content = item.attrs.find((a: any) => a.name === 'content')?.value || '';
+      return `<text id="${item.id}" ${attrs}>${content}</text>`;
+    }
+  }
+  return '';
+}

--- a/src/types/pegjs.d.ts
+++ b/src/types/pegjs.d.ts
@@ -1,0 +1,4 @@
+declare module 'pegjs' {
+  const peg: any;
+  export = peg;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- fix TypeScript config so `tsc` can resolve Node imports
- default CLI output to SVG and add `--html` option
- add fade-in animation example

## Testing
- `npm install`
- `npm run build`
- `node dist/cli/index.js examples/intro.glimma examples/intro.svg`
- `node dist/cli/index.js examples/intro.glimma examples/intro.html --html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a9bf302ec8329bfaaa9b2d5dccf5a