### PR TITLE
Add GitHub Actions for lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 20
+  - uses: actions/setup-node@v3
+    with:
+      node-version: 20
+      cache: 'npm'
     - run: npm ci
     - run: npm run lint
     - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 20
+    - run: npm ci
+    - run: npm run lint
+    - run: npm test

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ node dist/cli/index.js examples/intro.glimma examples/intro.svg
 | `glimma lint <file>`    | Validate syntax, report line/col errors.         |
 | `glimma init`           | Generate example scripts and CSS theme skeleton. |
 
+## Development
+
+Run TypeScript checks and tests with npm:
+
+```bash
+npm run lint
+npm test
+```
+
 ---
 
 ## Project status

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/cli/index.js",
   "scripts": {
     "build": "tsc",
+    "lint": "tsc --noEmit",
     "test": "npm run build && node --test"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add `lint` script to run `tsc --noEmit`
- run lint and tests in a CI workflow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bd8e254b88329ae3de4ea453f27cd