### PR TITLE
Fix scene timing gap

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -107,10 +107,10 @@ function renderCss(ast: ASTNode, totalDuration: number): string {
       );
       const sceneDuration = lastEntry.time + lastEntry.dur;
       sceneDurations.push({ name: scene.name, duration: sceneDuration, startTime: currentTime });
-      currentTime += sceneDuration + 1; // Add 1s gap between scenes
+      currentTime += sceneDuration + 3; // include fade durations and 1s gap
     } else {
       sceneDurations.push({ name: scene.name, duration: 5, startTime: currentTime }); // Default 5s for scenes without timeline
-      currentTime += 6;
+      currentTime += 8; // 5s scene + fade durations + 1s gap
     }
   }
   

--- a/test/error-handling.test.js
+++ b/test/error-handling.test.js
@@ -4,8 +4,8 @@ import { parse, SyntaxError } from '../dist/parser/index.js';
 
 test('parser reports syntax errors with line/column info', () => {
   const invalidGlimma = `scene demo {
-  shape box invalid_syntax
-  timeline:
+  shape box rect x=10 y=10
+  timeline
     0s: box fadeIn over 2s
 }`;
 

--- a/test/renderer.test.js
+++ b/test/renderer.test.js
@@ -12,3 +12,17 @@ test('renderSvg includes keyframes and shape', () => {
   assert.match(svg, /@keyframes fadeOut/);
   assert.match(svg, /<rect id="box"/);
 });
+
+const multiSceneSrc = `scene first {\n  shape a rect x=0 y=0 width=10 height=10\n  timeline:\n    0s: a fadeIn over 1s\n    1s: a fadeOut over 1s\n}\nscene second {\n  shape b rect x=20 y=0 width=10 height=10\n  timeline:\n    0s: b fadeIn over 1s\n    1s: b fadeOut over 1s\n}`;
+
+test('scene transitions do not overlap', () => {
+  const ast = parse(multiSceneSrc);
+  const svg = renderSvg(ast);
+  const firstMatch = svg.match(/#first { animation: sceneTransition-0 (\d+(?:\.\d+)?)s ease-in-out (\d+(?:\.\d+)?)s;/);
+  const secondMatch = svg.match(/#second { animation: sceneTransition-1 (\d+(?:\.\d+)?)s ease-in-out (\d+(?:\.\d+)?)s;/);
+  assert(firstMatch && secondMatch);
+  const firstDuration = parseFloat(firstMatch[1]);
+  const firstStart = parseFloat(firstMatch[2]);
+  const secondStart = parseFloat(secondMatch[2]);
+  assert(secondStart >= firstStart + firstDuration + 1);
+});


### PR DESCRIPTION
## Summary
- fix scene duration calculations so fade timings and scene gaps don't overlap
- adjust parser error test to actually fail with invalid syntax
- verify scenes transition without overlap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fc2bdf4388329886c1fc17d2e94e2